### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
 
       # build image
       - name: Build image
-        uses: elgohr/Publish-Docker-Github-Action@3.04
+        uses: elgohr/Publish-Docker-Github-Action@v5
         env:
           BRANCH: ${{ env.GITHUB_BRANCH }}
           BUILDNUMBER: ${{ github.run_number }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore